### PR TITLE
fix failing `firebase init`

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,2 @@
 {
-  "projects": {
-    "default": "test-58233"
-  }
 }


### PR DESCRIPTION
I tried this nice framework but `firebase init` said `Error: HTTP Error: 401, The entered credentials were incorrect.`
I modified `.firebaserc` and it works well.